### PR TITLE
added date parsing function

### DIFF
--- a/lymantria API pull.R
+++ b/lymantria API pull.R
@@ -9,6 +9,7 @@
 library(rinat)
 library(ggplot2)
 library(tidyverse)
+library(lubridate)
 
 #
 # set a geographic area for pulling data from

--- a/lymantria API pull.R
+++ b/lymantria API pull.R
@@ -19,6 +19,68 @@ bounds <- c(30,-90,50,-50)
 ld_dat <- get_inat_obs(taxon_name = "Lymantria dispar", bounds = bounds, maxresults=5000)
 
 
+# this function lets you take a dataframe and a date column and generate julian day and year
+# you can choose whether to parse date_col as datetime or just date
+# you can choose whether or not to keep the parsed date column or just julian day + year
+# as_datetime() takes timezone into account, converting everything to UTC
+
+make_julian_year <- function(data, date_col, datetime = F, keep_date_col = T){
+  
+  if(datetime){
+    data[,date_col] <- as_datetime(data[,date_col])
+  } else {
+    data[,date_col] <- as_date(data[,date_col])
+  }
+  
+  data$julian_day <- yday(data[,date_col])
+  data$year <- year(data[,date_col])
+
+  if(!keep_date_col){
+    data <- select(data, -all_of(date_col))
+  }
+
+  return(data)
+}
+
+ld_dat %>% 
+  select(datetime, common_name, observed_on) %>% 
+  make_julian_year("datetime", datetime = T) 
+
+# quick check to make sure that the only NA dates after conversion are due to empty dates, not due to parsing failures
+empty_dates <- ld_dat %>% 
+  filter(datetime == "") %>% 
+  nrow()
+
+missing_dates <- ld_dat %>% 
+  make_julian_year("datetime", datetime = T) %>% 
+  filter(is.na(datetime)) %>% 
+  nrow()
+
+empty_dates == missing_dates
+
+empty_dates <- ld_dat %>% 
+  filter(observed_on == "") %>% 
+  nrow()
+
+missing_dates <- ld_dat %>% 
+  make_julian_year("observed_on") %>% 
+  filter(is.na(observed_on)) %>% 
+  nrow()
+
+empty_dates == missing_dates
+
+# a little exploratory plotting, couldn't help myself
+ld_dat %>% 
+  select(datetime, common_name, observed_on) %>% 
+  make_julian_year("datetime", datetime = T) %>% 
+  filter(!is.na(year)) %>% 
+  mutate(year = as_factor(year) %>% 
+           fct_lump_min(20, other_level = "2003-2019") %>% 
+           fct_relevel("2003-2019")) %>% 
+  ggplot(aes(x = julian_day)) +
+  geom_histogram() +
+  facet_wrap(vars(year))
+
 
 # download just the location, dates, and ID data to use with the snack weevil methods:
 # commented out so I don't write over current dataframe 


### PR DESCRIPTION
Hi Rob- as I noted in my email, I wasn't sure exactly which date columns to use for generating Julian days and years, so I wrote a function that should generalize to any of them. I focused on the two that you referenced later on in the script, `datetime` and `observed_on`. 

I also ran a couple quick checks to ensure that there were no date parsing failures and that all parsed dates with an `NA` came from empty date strings in the original columns. Also did a quick little visualization as a sanity check for the distributions of observations through time.